### PR TITLE
Add options `--ignore-maven-local` and `--arg`

### DIFF
--- a/app/src/dist/share/gradle-env.nix
+++ b/app/src/dist/share/gradle-env.nix
@@ -67,6 +67,7 @@ let
             buildscript {
               repositories {
                 clear()
+                maven { url = uri("${repos.plugin}") }
                 maven { url = uri("${repos.buildscript}") }
               }
             }

--- a/app/src/main/kotlin/org/nixos/gradle2nix/GradleRunner.kt
+++ b/app/src/main/kotlin/org/nixos/gradle2nix/GradleRunner.kt
@@ -17,16 +17,22 @@ fun connect(config: Config): ProjectConnection =
 
 fun ProjectConnection.getBuildModel(config: Config, path: String): DefaultBuild {
     val arguments = mutableListOf(
-        "--init-script=$shareDir/init.gradle",
-        "-Dorg.nixos.gradle2nix.configurations='${config.configurations.joinToString(",")}'"
+        "--init-script=$shareDir/init.gradle"
     )
-
+    arguments += config.args
     if (path.isNotEmpty()) {
         arguments += "--project-dir=$path"
+    }
+    val jvmArguments = mutableListOf(
+        "-Dorg.nixos.gradle2nix.ignoreMavenLocal=${config.ignoreMavenLocal}"
+    )
+    if (config.configurations.isNotEmpty()) {
+        jvmArguments += "-Dorg.nixos.gradle2nix.configurations='${config.configurations.joinToString(",")}'"
     }
 
     return model(Build::class.java)
         .withArguments(arguments)
+        .addJvmArguments(jvmArguments)
         .apply {
             if (!config.quiet) {
                 setStandardOutput(System.err)

--- a/app/src/main/kotlin/org/nixos/gradle2nix/Main.kt
+++ b/app/src/main/kotlin/org/nixos/gradle2nix/Main.kt
@@ -25,7 +25,9 @@ data class Config(
     val projectDir: File,
     val includes: List<File>,
     val buildSrc: Boolean,
-    val quiet: Boolean
+    val quiet: Boolean,
+    val args: List<String>,
+    val ignoreMavenLocal: Boolean
 ) {
     val allProjects = listOf(projectDir) + includes
 }
@@ -80,6 +82,15 @@ class Main : CliktCommand(
         .projectDir()
         .default(File("."))
 
+    private val args: List<String> by option("--arg", "-a",
+            metavar = "ARGUMENT",
+            help = "Add an extra argument to the build.gradle")
+            .multiple()
+
+    private val ignoreMavenLocal: Boolean by option("--ignore-maven-local",
+            help = "Don't include mavenLocal() repositories")
+            .flag()
+
     init {
         context {
             helpFormatter = CliktHelpFormatter(showDefaultValues = true)
@@ -87,7 +98,7 @@ class Main : CliktCommand(
     }
 
     override fun run() {
-        val config = Config(wrapper, gradleVersion, configurations, projectDir, includes, buildSrc, quiet)
+        val config = Config(wrapper, gradleVersion, configurations, projectDir, includes, buildSrc, quiet, args, ignoreMavenLocal)
         val (log, _, _) = Logger(verbose = !config.quiet)
 
         val paths = resolveProjects(config).map { p ->


### PR DESCRIPTION
* Option `--ignore-maven-local` skips `mavenLocal()` repositories so the resulting `.json`-file is less machine-specific
* Option `--arg` allows one to pass arguments through to the underling `build.gradle`, e.g. `--arg -PMY_VERSION_SETTING=foo --arg -PMY_NUMBER=42` etc.
