### PR TITLE
make gradle2nix build using nix-prefetch-url sha256

### DIFF
--- a/gradle-env.json
+++ b/gradle-env.json
@@ -3729,7 +3729,7 @@
             "https://jcenter.bintray.com/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.pom",
             "https://repo.gradle.org/gradle/libs-releases/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.pom"
           ],
-          "sha256": "b31109e22ea3f2df1ad7955432e718a35def50ae6c19698034afa8a0cf9e9069"
+          "sha256": "06nwnhhgy4gg4q3bs2dx0311qabqcqcnfkbplmdi8350lgh2mbbg"
         },
         {
           "id": {


### PR DESCRIPTION
While installing gradle2nix today, I came across this error:

```
hash mismatch in fixed-output derivation '/nix/store/0n8l74f6210fhprs6f4h1b9x3x1jbgf1-javax.servlet-api-3.1.0.pom':                                                                                                                                                                             
  wanted: sha256:0schkv7s1a5g6j06j6bcmr8fypd333kk4m4mswddzwm35vi0j4dk                                                                                                                                                                                                                           
  got:    sha256:06nwnhhgy4gg4q3bs2dx0311qabqcqcnfkbplmdi8350lgh2mbbg                                                                                                                                                                                                                           
cannot build derivation '/nix/store/b6k5p1zdqbji2ddpbk64fbgv9z2y39fq-javax.servlet-api-3.1.0.pom.drv': 1 dependencies couldn't be built                                                                                                                                                         
```

I've updated gradle-env.json with the output from nix-prefetch-url (which defaults to sha256):
```
$ nix-prefetch-url https://jcenter.bintray.com/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.pom
path is '/nix/store/0n8l74f6210fhprs6f4h1b9x3x1jbgf1-javax.servlet-api-3.1.0.pom'
06nwnhhgy4gg4q3bs2dx0311qabqcqcnfkbplmdi8350lgh2mbbg

$ nix-prefetch-url https://repo.gradle.org/gradle/libs-releases/javax/servlet/javax.servlet-api/3.1.0/javax.servlet-api-3.1.0.pom
path is '/nix/store/0n8l74f6210fhprs6f4h1b9x3x1jbgf1-javax.servlet-api-3.1.0.pom'
06nwnhhgy4gg4q3bs2dx0311qabqcqcnfkbplmdi8350lgh2mbbg
```

I think this closes #26