### PR TITLE
gradle-env.nix: Don't pass fetchers to mkDerivation

### DIFF
--- a/gradle-env.nix
+++ b/gradle-env.nix
@@ -371,7 +371,7 @@ let
 
   buildRootProject = buildProject projectEnv gradleFlags;
 
-in stdenv.mkDerivation (args // {
+in stdenv.mkDerivation ((builtins.removeAttrs args [ "fetchers" ]) // {
 
   inherit pname version;
 


### PR DESCRIPTION
If using the `fetchers` argument with `buildGradle`, it ultimately tries to pass through the `fetchers` to the underlying `mkDerivation`. This causes the following error, since `mkDerivation` doesn't expect a `fetchers` attrset:
```
error: cannot coerce a set to a string
```