### PR TITLE
Respect buildscript constraints when resolving plugins

### DIFF
--- a/plugin/src/main/kotlin/org/nixos/gradle2nix/PluginResolver.kt
+++ b/plugin/src/main/kotlin/org/nixos/gradle2nix/PluginResolver.kt
@@ -7,7 +7,7 @@ import org.gradle.plugin.use.internal.PluginDependencyResolutionServices
 import javax.inject.Inject
 
 internal open class PluginResolver @Inject constructor(
-    project: Project,
+    private val project: Project,
     pluginDependencyResolutionServices: PluginDependencyResolutionServices
 ) {
     private val configurations = pluginDependencyResolutionServices.configurationContainer
@@ -26,6 +26,8 @@ internal open class PluginResolver @Inject constructor(
                 ApiHack.defaultExternalModuleDependency(id, "$id.gradle.plugin", request.version)
             }
         }
-        return resolver.resolve(configurations.detachedConfiguration(*markerDependencies.toTypedArray()))
+        return resolver.resolve(configurations.detachedConfiguration(*markerDependencies.toTypedArray()).apply {
+            dependencyConstraints.addAll(project.buildscript.configurations.flatMap { it.allDependencyConstraints })
+        })
     }
 }


### PR DESCRIPTION
Currently, gradle2nix resolves plugins with their declared dependencies, not taking into account any constraints that the buildscript classpath configuration has. This results in the dependencies in the generated repository being different from the dependencies that gradle attempts to resolve during `nix-build`.

This causes problems when using the Kotlin JVM plugin, as the buildscript classpath configuration has a constraint that the Kotlin libraries be exactly the embedded Kotlin version. This is seen in a (hopefully) minimal reproduction: https://github.com/randomnetcat/gradle2nix-failure-case.

In that reproduction, gradle under `nix-build` gives the following error:
```
Caused by: org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration$ArtifactResolveException: Could not resolve all artifacts for configuration ':classpath'.

[...]

Cause 1: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.jetbrains.kotlin:kotlin-stdlib:1.4.31.
Searched in the following locations:
  - file:/nix/store/kcmrzfz51zzb084nnpf4rjf33rs5fa49-gradle2nix-repro-gradle-plugin-env/org/jetbrains/kotlin/kotlin-stdlib/1.4.31/kotlin-stdlib-1.4.31.module
  - file:/nix/store/kcmrzfz51zzb084nnpf4rjf33rs5fa49-gradle2nix-repro-gradle-plugin-env/org/jetbrains/kotlin/kotlin-stdlib/1.4.31/kotlin-stdlib-1.4.31.pom
  - file:/nix/store/kcmrzfz51zzb084nnpf4rjf33rs5fa49-gradle2nix-repro-gradle-plugin-env/org/jetbrains/kotlin/kotlin-stdlib/1.4.31/kotlin-stdlib-1.4.31.jar
  - file:/nix/store/kcmrzfz51zzb084nnpf4rjf33rs5fa49-gradle2nix-repro-gradle-plugin-env/org/jetbrains/kotlin/kotlin-stdlib/1.4.31/ivy-1.4.31.xml
Required by:
    project :
Cause 2: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.jetbrains.kotlin:kotlin-reflect:1.4.31.
Searched in the following locations:
  - file:/nix/store/kcmrzfz51zzb084nnpf4rjf33rs5fa49-gradle2nix-repro-gradle-plugin-env/org/jetbrains/kotlin/kotlin-reflect/1.4.31/kotlin-reflect-1.4.31.module
  - file:/nix/store/kcmrzfz51zzb084nnpf4rjf33rs5fa49-gradle2nix-repro-gradle-plugin-env/org/jetbrains/kotlin/kotlin-reflect/1.4.31/kotlin-reflect-1.4.31.pom
  - file:/nix/store/kcmrzfz51zzb084nnpf4rjf33rs5fa49-gradle2nix-repro-gradle-plugin-env/org/jetbrains/kotlin/kotlin-reflect/1.4.31/kotlin-reflect-1.4.31.jar
  - file:/nix/store/kcmrzfz51zzb084nnpf4rjf33rs5fa49-gradle2nix-repro-gradle-plugin-env/org/jetbrains/kotlin/kotlin-reflect/1.4.31/ivy-1.4.31.xml
Required by:
    project :

[...]
```

In the generated plugin repo, the only `kotlin-stdlib` that is included has version `1.5.0`. With this patch, the repo instead has only a `kotlin-stdlib` with version `1.4.31`, matching the embedded kotlin version, letting the build complete successfully.