### PR TITLE
FIX:  Flake installation fails with hash mismatch #51 

### DIFF
--- a/gradle-env.json
+++ b/gradle-env.json
@@ -71,7 +71,7 @@
           "urls": [
             "https://plugins.gradle.org/m2/com/fasterxml/jackson/jackson-parent/2.12/jackson-parent-2.12.pom"
           ],
-          "sha256": "Z749r6r4zhcX56fefbkrpDPfkjtpekDJdDpUzJ/FNjc="
+          "sha256": "YqocFnmt4J8XPb8bbDLTXFXnWAAjj9XkjxOqQzfAh1s="
         },
         {
           "id": {


### PR DESCRIPTION
Updated the hash so that I could build the flake. 

#51 