### PR TITLE
[v2] Add support for Android builds

### DIFF
--- a/gradle.nix
+++ b/gradle.nix
@@ -102,6 +102,9 @@ in
   #      "org.apache.log4j:core:2.23.1" = null;
   #    })
   overlays ? [ ],
+  # Build inputs which need to be added to the Gradle build. 
+  # For example, in can be used to pass Android SDK for Android and Kotlin Multiplatform app builds.
+  extraBuildInputs ? [ ],
   ...
 }@args:
 
@@ -183,7 +186,7 @@ let
 
       dontStrip = true;
 
-      nativeBuildInputs = [ finalAttrs.gradle ];
+      nativeBuildInputs = [ finalAttrs.gradle ] ++ extraBuildInputs;
 
       buildPhase =
         let
@@ -195,6 +198,7 @@ let
               "--no-daemon"
               "--no-watch-fs"
               "--offline"
+              "-Duser.home=$(mktemp -d)"
             ]
             ++ lib.optional (finalAttrs.buildJdk != null) "-Dorg.gradle.java.home=${finalAttrs.buildJdk.home}"
             ++ lib.optional finalAttrs.enableDebug "-Dorg.gradle.debug=true"


### PR DESCRIPTION
# Summary

This change improves gradle2nix's compatibility with Android builds.

* Fixes the error in which build fails to write to `/var/empty/.android` directory on macOS.
Android Gradle Plugin uses `$HOME/.android` directory (see ANDROID_USER_HOME variable https://developer.android.com/tools/variables#envar) to store plugin preferences and signing keystores, among other things.
However the directory becomes the read-only `/var/empty/.android` in Nix builds, and the plugin fails to write there.
The PR fixes the problem by setting `user.home` Gradle parameter to a temporary directory. It is enough to produce an unsigned APK.
* Allow passing extra build inputs by introducing an `extraBuildInputs`. For instance, it can be used to pass an environment with Android SDK set up.

# How to test

The change can be tested by building [this Gradle project](https://github.com/lunaticare/identity-samples/tree/feature/gradle2nix_build/CredentialManager):

```
nix build 'github:lunaticare/identity-samples?ref=feature/gradle2nix_build&dir=CredentialManager#packages.aarch64-darwin.android-app'
find -L ./result
```

```
./result
./result/apk
./result/apk/release
./result/apk/release/output-metadata.json
./result/apk/release/app-release.apk
./result/apk/debug
./result/apk/debug/output-metadata.json
./result/apk/debug/app-debug.apk
```