### PR TITLE
V2: Fix `buildGradlePackage` overrides

### DIFF
--- a/nix/build-gradle-package.nix
+++ b/nix/build-gradle-package.nix
@@ -137,7 +137,7 @@ let
       "lockFile"
       "fetchers"
       "nativeBuildInputs"
-      "overlays"
+      "overrides"
       "passthru"
     ]
   );


### PR DESCRIPTION
`removeAttrs` removes the wrong attr, it should be `overrides` not `overlays`. Otherwise you get this:
```nix
warning: Git tree '/home/ashley/projects/gradle2nix' is dirty
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'gradle2nix-2.0.0'
         whose name attribute is located at /nix/store/dydg48djlykksz8cxq0xjplyxpa9pvf4-source/pkgs/stdenv/generic/make-derivation.nix:331:7

       … while evaluating attribute 'overrides' of derivation 'gradle2nix-2.0.0'

         at /nix/store/x11vcpas41sisbl9fj9idb5y1fnsxpih-source/default.nix:49:5:

           48|
           49|     overrides = {};
             |     ^
           50|

       error: cannot coerce a set to a string
```