### PR TITLE
remove gradle flag --console=plain

### DIFF
--- a/nix/build-gradle-package.nix
+++ b/nix/build-gradle-package.nix
@@ -102,7 +102,7 @@ let
       nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ finalAttrs.gradleSetupHook ];
 
       gradleFlags =
-        [ "--console=plain" ]
+        [ ]
         ++ lib.optional (finalAttrs.buildJdk != null) "-Dorg.gradle.java.home=${finalAttrs.buildJdk.home}";
 
       passthru =


### PR DESCRIPTION
the option `--console=plain` makes `gradle` fail with

> Multiple arguments were provided for command-line option

because [gradleSetupHook](https://github.com/NixOS/nixpkgs/blob/dd34eb55bef12e02ba3eac902de1d9f0c22c08aa/pkgs/development/tools/build-managers/gradle/setup-hook.sh#L7) already adds `--console plain` since [2024-07-12](https://github.com/NixOS/nixpkgs/commit/c12b2a0b196a42a20949cf648c86acfbe6418ad3)

see also https://github.com/gradle/gradle/issues/30913

FIXME update `nixpkgs` in `flake.lock`
this error only happens when calling gradle2nix from non-flake nix