### PR TITLE
fix: ensure correct file names for downloads

### DIFF
--- a/nix/build-maven-repo.nix
+++ b/nix/build-maven-repo.nix
@@ -128,7 +128,7 @@ let
     let
       scheme = head (builtins.match "([a-z0-9+.-]+)://.*" url);
       fetch' = getAttr scheme fetchers';
-      artifact = fetch' { inherit url hash; };
+      artifact = fetch' { inherit url hash name; };
       override = overrides.${name} or lib.id;
     in
     override artifact;


### PR DESCRIPTION
When the name of an artifact did not match the last segment of the URL, it was saved under the incorrect name. This is now rectified.