### PR TITLE
update args help text

### DIFF
--- a/app/src/main/kotlin/org/nixos/gradle2nix/Main.kt
+++ b/app/src/main/kotlin/org/nixos/gradle2nix/Main.kt
@@ -165,7 +165,7 @@ class Gradle2Nix :
 
     private val gradleArgs: List<String> by argument(
         name = "ARGS",
-        help = "Extra arguments to pass to Gradle",
+        help = "Extra arguments to pass to Gradle. Hint: Prefix with arg --",
     ).multiple()
 
     init {


### PR DESCRIPTION
without `--` gradle2nix says

```
$ gradle2nix --warning-mode all
Usage: gradle2nix [<options>] [<args>]...

Error: no such option --warning-mode
```

the args should be

```
gradle2nix -- --warning-mode all
```
